### PR TITLE
Support parallelism

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: "^1.18.0"
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,7 +19,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.30
+          version: v1.45.12
 
           # Optional: golangci-lint command line arguments.
           #args: --issues-exit-code=0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,9 +30,6 @@ jobs:
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 
-          # Optional: if set to true then the action will use pre-installed Go.
-          skip-go-installation: true
-
           # Optional: if set to true then the action don't cache or restore ~/go/pkg.
           # skip-pkg-cache: true
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.17.2"
+          go-version: "^1.18.0"
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           go-version: "^1.18.0"
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.45.12
+          version: latest
 
           # Optional: golangci-lint command line arguments.
           #args: --issues-exit-code=0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,7 +19,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.30
 
           # Optional: golangci-lint command line arguments.
           #args: --issues-exit-code=0

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ node_modules
 
 # Ignore Sonarcloud Scanner Github Action temp files
 .scannerwork/
+
+# Ignore local build file
+main

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/StackExchange/wmi v1.2.1 // indirect
+	github.com/alexflint/go-filemutex v1.2.0
 	github.com/aws/aws-sdk-go v1.40.59
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/dustin/go-humanize v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,12 @@
 module github.com/aripalo/vegas-credentials
 
-go 1.16
+go 1.18
 
 require (
-	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/alexflint/go-filemutex v1.2.0
 	github.com/aws/aws-sdk-go v1.40.59
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/dustin/go-humanize v1.0.0
-	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gookit/color v1.4.2
 	github.com/iancoleman/strcase v0.2.0
 	github.com/mattn/go-colorable v0.1.11
@@ -18,8 +16,48 @@ require (
 	github.com/shirou/gopsutil v3.21.10-0.20211020152436-d863ea4cc5fb+incompatible
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0
-	github.com/tklauser/go-sysconf v0.3.9 // indirect
-	golang.org/x/sys v0.0.0-20211015200801-69063c4bb744 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/ini.v1 v1.63.2
+)
+
+require (
+	github.com/StackExchange/wmi v1.2.1 // indirect
+	github.com/akavel/rsrc v0.10.2 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/dchest/jsmin v0.0.0-20160823214000-faeced883947 // indirect
+	github.com/dgraph-io/ristretto v0.1.0 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/flatbuffers v1.12.1 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/josephspurrier/goversioninfo v1.3.0 // indirect
+	github.com/klauspost/compress v1.12.3 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.9 // indirect
+	github.com/tklauser/numcpus v0.3.0 // indirect
+	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d // indirect
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
+	golang.org/x/sys v0.0.0-20211015200801-69063c4bb744 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/akavel/rsrc v0.10.2 h1:Zxm8V5eI1hW4gGaYsJQUhxpjkENuG91ki8B4zCrvEsw=
 github.com/akavel/rsrc v0.10.2/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
+github.com/alexflint/go-filemutex v1.2.0 h1:1v0TJPDtlhgpW4nJ+GvxCLSlUDC3+gW0CQQvlmfDR/s=
+github.com/alexflint/go-filemutex v1.2.0/go.mod h1:mYyQSWvw9Tx2/H2n9qXPb52tTYfE0pZAWcBq5mK025c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -31,7 +31,10 @@ func Lock() func() error {
 		log.Fatalln("Directory did not exist or file could not created")
 	}
 
-	m.Lock() // Will block until lock can be acquired
+	err = m.Lock() // Will block until lock can be acquired
+	if err != nil {
+		log.Fatalln("Directory lock could not be made")
+	}
 
 	// return the unlock function which user can call
 	return m.Unlock

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -15,7 +15,7 @@ type NewCache struct {
 	db *database.Database
 }
 
-// Lock helps with parallel executions (e.g. with Terraform --concurrent)
+// Lock helps with parallel executions (e.g. with Terraform parallelism=n)
 // ensuring only a single process at a time can interact with AWS and
 // the internal cache – as the BadgerDB requires a filelock:
 // https://github.com/dgraph-io/badger/blob/69926151f6532f2fe97a9b11ee9281519c8ec5e6/dir_unix.go#L45

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,15 +1,40 @@
 package cache
 
 import (
+	"log"
 	"time"
 
+	"github.com/alexflint/go-filemutex"
 	"github.com/aripalo/vegas-credentials/internal/cache/database"
 	"github.com/aripalo/vegas-credentials/internal/cache/encryption"
+	"github.com/aripalo/vegas-credentials/internal/config"
 )
 
 // NewCache (and its methods) describes the caching mechanism
 type NewCache struct {
 	db *database.Database
+}
+
+// Lock helps with parallel executions (e.g. with Terraform --concurrent)
+// ensuring only a single process at a time can interact with AWS and
+// the internal cache – as the BadgerDB requires a filelock:
+// https://github.com/dgraph-io/badger/blob/69926151f6532f2fe97a9b11ee9281519c8ec5e6/dir_unix.go#L45
+//
+// An "unlock function" is returned which removes the directory lock, allowing
+// other processes to continue.
+func Lock() func() error {
+	// as we can't lock the BadgerDB directory (since BadgerDB has its own lock),
+	// we use this "lock-control" directory to achieve the desired result
+	cachePath := CachePath(config.APP_NAME, "lock-control")
+	m, err := filemutex.New(cachePath)
+	if err != nil {
+		log.Fatalln("Directory did not exist or file could not created")
+	}
+
+	m.Lock() // Will block until lock can be acquired
+
+	// return the unlock function which user can call
+	return m.Unlock
 }
 
 // New instantiates a cache

--- a/internal/commands/assume/app.go
+++ b/internal/commands/assume/app.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/aripalo/vegas-credentials/internal/cache"
 	"github.com/aripalo/vegas-credentials/internal/config"
 	"github.com/aripalo/vegas-credentials/internal/logger"
 	"github.com/aripalo/vegas-credentials/internal/profile"
@@ -73,10 +74,17 @@ func (app *App) PreRunE(cmd *cobra.Command) error {
 // Run executes the cobra command (but does not directly depend on cobra)
 func (app *App) Run() {
 
+	unlock := cache.Lock()
+
 	err := getCredentials(app)
 
+	unlockErr := unlock()
+	if unlockErr != nil {
+		panic(unlockErr) // TODO handle better
+	}
+
 	if err != nil {
-		panic(err)
+		panic(err) // TODO handle better
 	}
 
 }

--- a/internal/commands/assume/app.go
+++ b/internal/commands/assume/app.go
@@ -2,6 +2,7 @@ package assume
 
 import (
 	"io"
+	"log"
 	"time"
 
 	"github.com/aripalo/vegas-credentials/internal/cache"
@@ -80,11 +81,11 @@ func (app *App) Run() {
 
 	unlockErr := unlock()
 	if unlockErr != nil {
-		panic(unlockErr) // TODO handle better
+		log.Fatalln("could not release the directory lock")
 	}
 
 	if err != nil {
-		panic(err) // TODO handle better
+		log.Fatalln(err)
 	}
 
 }


### PR DESCRIPTION
Tools such as Terraform (via `parallelism=n` – which defaults to `10`) can invoke the `vegas-credentials` credential process concurrently, leading into problematic situations where multiple `vegas-credentials` processes are and/or:
1. prompting the user for MFA
2. accessing the filesystem cache which results into error as: 
    >  _[Badger obtains a lock on the directories so multiple processes cannot open the same database at the same time](https://dgraph.io/docs/badger/get-started/#opening-a-database)_

To circumvent this, we use [`alexflint/go-filemutex`](https://github.com/alexflint/go-filemutex) to assign a lock to a specific `lock-control` directory at the beginning of the command and unlocking the directly once the main command (`getCredentials` function) has been executed.