### PR TITLE
fix: use new MutexControl

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,52 +1,15 @@
 package cache
 
 import (
-	"log"
-	"os"
 	"time"
 
-	"github.com/alexflint/go-filemutex"
 	"github.com/aripalo/vegas-credentials/internal/cache/database"
 	"github.com/aripalo/vegas-credentials/internal/cache/encryption"
-	"github.com/aripalo/vegas-credentials/internal/config"
 )
 
 // NewCache (and its methods) describes the caching mechanism
 type NewCache struct {
 	db *database.Database
-}
-
-// Lock helps with parallel executions (e.g. with Terraform parallelism=n)
-// ensuring only a single process at a time can interact with AWS and
-// the internal cache – as the BadgerDB requires a filelock:
-// https://github.com/dgraph-io/badger/blob/69926151f6532f2fe97a9b11ee9281519c8ec5e6/dir_unix.go#L45
-//
-// An "unlock function" is returned which removes the directory lock, allowing
-// other processes to continue.
-func Lock() func() error {
-	// as we can't lock the BadgerDB directory (since BadgerDB has its own lock),
-	// we use this "lock-control" directory to achieve the desired result
-	cachePath := CachePath(config.APP_NAME, "lock-control")
-
-	// the base directory must exists before hand so use MkdirAll
-	err := os.MkdirAll(cachePath, os.ModePerm)
-	if err != nil {
-		log.Fatalln("Could not create cache lock-control file")
-	}
-
-	// create the filemutex
-	m, err := filemutex.New(cachePath)
-	if err != nil {
-		log.Fatalln("Directory did not exist or file could not created")
-	}
-
-	err = m.Lock() // Will block until lock can be acquired
-	if err != nil {
-		log.Fatalln("Directory lock could not be made")
-	}
-
-	// return the unlock function which user can call
-	return m.Unlock
 }
 
 // New instantiates a cache

--- a/internal/commands/assume/app.go
+++ b/internal/commands/assume/app.go
@@ -82,7 +82,10 @@ func (app *App) Run() {
 	if err != nil {
 		log.Fatalln(fmt.Sprintf("configuration error: %v", err))
 	}
-	mc.Lock()
+	err = mc.Lock()
+	if err != nil {
+		log.Fatalln(fmt.Sprintf("mutex error: %v", err))
+	}
 
 	err = getCredentials(app)
 

--- a/internal/commands/assume/app.go
+++ b/internal/commands/assume/app.go
@@ -1,13 +1,14 @@
 package assume
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"time"
 
-	"github.com/aripalo/vegas-credentials/internal/cache"
 	"github.com/aripalo/vegas-credentials/internal/config"
 	"github.com/aripalo/vegas-credentials/internal/logger"
+	"github.com/aripalo/vegas-credentials/internal/mutex"
 	"github.com/aripalo/vegas-credentials/internal/profile"
 	"github.com/spf13/cobra"
 )
@@ -75,11 +76,17 @@ func (app *App) PreRunE(cmd *cobra.Command) error {
 // Run executes the cobra command (but does not directly depend on cobra)
 func (app *App) Run() {
 
-	unlock := cache.Lock()
+	mutexPath := config.MutexLockFile
+	//msg.Message.Debugln("🔧", fmt.Sprintf("Path: Mutex: %s", mutexPath))
+	mc, err := mutex.New(mutexPath)
+	if err != nil {
+		log.Fatalln(fmt.Sprintf("configuration error: %v", err))
+	}
+	mc.Lock()
 
-	err := getCredentials(app)
+	err = getCredentials(app)
 
-	unlockErr := unlock()
+	unlockErr := mc.Unlock()
 	if unlockErr != nil {
 		log.Fatalln("could not release the directory lock")
 	}

--- a/internal/config/files.go
+++ b/internal/config/files.go
@@ -1,0 +1,6 @@
+package config
+
+// Describes the path for a file used to control parallelism via file locks.
+var MutexLockFile string = func(filename string) string {
+	return TempFilePath(filename)
+}("mutex-lock")

--- a/internal/config/temp.go
+++ b/internal/config/temp.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// TempDir denotes a directory where to store temporary files.
+// OS specific. On Unix-based machines follows $TMPDIR.
+var TempDir string = func(appName string) string {
+	dir := filepath.Join(os.TempDir(), appName)
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+	return dir
+}(APP_NAME)
+
+// TempFilePath returns a full path for given filename for temporary use.
+// The path should not change between consecutive executions.
+// On Unix-based machines follows $TMPDIR.
+func TempFilePath(filename string) string {
+	return filepath.Join(TempDir, filename)
+}

--- a/internal/mutex/lock.go
+++ b/internal/mutex/lock.go
@@ -1,0 +1,51 @@
+package mutex
+
+import (
+	"errors"
+	"os"
+	"path"
+
+	"github.com/alexflint/go-filemutex"
+)
+
+type MutexControl struct {
+	dir  string
+	file string
+	path string
+
+	// Will block until lock can be acquired
+	Lock func() error
+
+	// Releases the lock
+	Unlock func() error
+}
+
+// Helps with parallel executions (e.g. with Terraform parallelism=n)
+// ensuring only a single process at a time can interact with AWS and
+// the internal cache – as the BadgerDB requires a filelock:
+// https://github.com/dgraph-io/badger/blob/69926151f6532f2fe97a9b11ee9281519c8ec5e6/dir_unix.go#L45
+func New(dir string) (MutexControl, error) {
+	file := "mutexlock"
+	m := MutexControl{
+		dir:  dir,
+		file: file,
+		path: path.Join(dir, file),
+	}
+
+	// the base directory must exists before hand so use MkdirAll
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return m, errors.New("Could not create cache lock-control file")
+	}
+
+	// create the filemutex
+	fm, err := filemutex.New(m.path)
+	if err != nil {
+		return m, errors.New("Directory did not exist or file could not created")
+	}
+
+	m.Lock = fm.Lock
+	m.Unlock = fm.Unlock
+
+	return m, nil
+}


### PR DESCRIPTION
Uses an actual file as the mutex, not directory.

Implementation from next version of vegas-credentials, but introduced here to fix issues with existing users.