### PR TITLE
feat: resolve fallback value for role session name

### DIFF
--- a/internal/assumecfg/new.go
+++ b/internal/assumecfg/new.go
@@ -39,7 +39,7 @@ func New[D awsini.DataSource](dataSource D, profileName string) (AssumeCfg, erro
 		SourceProfile:   role.SourceProfile,
 		RoleArn:         role.RoleArn,
 		DurationSeconds: resolveDurationSeconds(role.DurationSeconds),
-		RoleSessionName: role.RoleSessionName,
+		RoleSessionName: resolveRoleSessionName(role.RoleSessionName),
 		ExternalID:      role.ExternalID,
 	}
 

--- a/internal/assumecfg/new_test.go
+++ b/internal/assumecfg/new_test.go
@@ -25,9 +25,10 @@ func TestNewAssumable(t *testing.T) {
 				MfaSerial:       "arn:aws:iam::111111111111:mfa/FrankSinatra",
 				YubikeyLabel:    "arn:aws:iam::111111111111:mfa/FrankSinatra",
 				RoleArn:         "arn:aws:iam::222222222222:role/SingerRole",
+				RoleSessionName: "SinatraAtTheSands",
 				SourceProfile:   "default",
 				DurationSeconds: 3600,
-				Checksum:        "d8fdfde29a33d93a04f2c81a014d3558fe09f1c7",
+				Checksum:        "d5656b38d196c58de4ab1e2cdd5e2715611e9282",
 			},
 		},
 		{

--- a/internal/assumecfg/resolvers.go
+++ b/internal/assumecfg/resolvers.go
@@ -77,6 +77,12 @@ func getSessionIdentifier() string {
 func format(id string) string {
 	cleaned := removeDisallowed(id)
 	truncated := truncate(cleaned)
+
+	// handle extremely rare situation where the cleaned string is too short
+	if len(truncated) <= minLength {
+		return fmt.Sprintf("mysession-%s", truncated)
+	}
+
 	return truncated
 }
 

--- a/internal/assumecfg/resolvers.go
+++ b/internal/assumecfg/resolvers.go
@@ -1,7 +1,11 @@
 package assumecfg
 
 import (
+	"fmt"
 	"os"
+	"os/user"
+	"regexp"
+	"runtime"
 )
 
 const DurationSecondsDefault int = 3600
@@ -28,4 +32,68 @@ func resolveDurationSeconds(durationSeconds int) int {
 		return durationSeconds
 	}
 	return DurationSecondsDefault
+}
+
+var minLength = 2
+
+func resolveRoleSessionName(roleSessionName string) string {
+	if len(roleSessionName) >= minLength {
+		return roleSessionName
+	}
+
+	id := getSessionIdentifier()
+	val := format(id)
+
+	return val
+}
+
+func getSessionIdentifier() string {
+
+	// Let's first try getting user info
+	if u, err := user.Current(); err == nil {
+
+		// Return user full name if meaningful
+		if len(u.Name) >= minLength {
+			return u.Name
+		}
+
+		// Return user (system) name if meaningful
+		if len(u.Username) >= minLength {
+			return u.Username
+		}
+	}
+
+	// If username not found, return hostname if meaningful
+	if hostname, err := os.Hostname(); err == nil {
+		if len(hostname) >= minLength {
+			return hostname
+		}
+	}
+
+	// If no other value could not be resolved, use system info
+	return fmt.Sprintf("%s_%s\n", runtime.GOOS, runtime.GOARCH)
+}
+
+func format(id string) string {
+	cleaned := removeDisallowed(id)
+	truncated := truncate(cleaned)
+	return truncated
+}
+
+/*
+must be alphanumeric, including the following common characters: plus (+), equal (=), comma (,), period (.), at (@), underscore (_), and hyphen (-).
+https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length
+*/
+var disallowed = `[^a-zA-Z0-9_+=,.@-]`
+var disallowedRegexp = regexp.MustCompile(disallowed)
+
+func removeDisallowed(value string) string {
+	return disallowedRegexp.ReplaceAllString(value, "")
+}
+
+func truncate(value string) string {
+	if len(value) > 64 {
+		return value[:64]
+	}
+	return value
 }

--- a/internal/assumecfg/resolvers.go
+++ b/internal/assumecfg/resolvers.go
@@ -86,11 +86,8 @@ func format(id string) string {
 	return truncated
 }
 
-/*
-must be alphanumeric, including the following common characters: plus (+), equal (=), comma (,), period (.), at (@), underscore (_), and hyphen (-).
-https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length
-*/
-var disallowed = `[^a-zA-Z0-9_+=,.@-]`
+// https://aws.amazon.com/blogs/security/easily-control-naming-individual-iam-role-sessions/
+var disallowed = `[^a-zA-Z0-9_=,.@-]`
 var disallowedRegexp = regexp.MustCompile(disallowed)
 
 func removeDisallowed(value string) string {

--- a/internal/assumecfg/testdata/valid-minimal.ini
+++ b/internal/assumecfg/testdata/valid-minimal.ini
@@ -5,3 +5,4 @@ mfa_serial = arn:aws:iam::111111111111:mfa/FrankSinatra
 credential_process = vegas-credentials assume --profile=frank@concerts
 vegas_role_arn=arn:aws:iam::222222222222:role/SingerRole
 vegas_source_profile=default
+role_session_name=SinatraAtTheSands

--- a/website/docs/role-session-name.md
+++ b/website/docs/role-session-name.md
@@ -23,4 +23,4 @@ role_session_name = SinatraAtTheSands
 3. System Hostname: e.g. `work-laptop`
 4. Combination of OS & Architecture: e.g. `darwin_amd64`
 
-It also removes disallowed characters and truncates the string to match the requirements of [IAM names](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length).
+It also removes disallowed characters and truncates the string to match the [requirements](https://aws.amazon.com/blogs/security/easily-control-naming-individual-iam-role-sessions/).

--- a/website/docs/role-session-name.md
+++ b/website/docs/role-session-name.md
@@ -18,9 +18,9 @@ role_session_name = SinatraAtTheSands
 ## Fallback value
 
 [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) requires Role Session Name value to be set. If you do not provide one, Vegas Credentials will use a fallback value which is one of the following (in the following priority):
-1. User Full Name: e.g. `John Doe`
-2. User (System) Name: e.g. `john`
-3. System Hostname: e.g. `work-laptop`
+1. User Full Name: e.g. `Frank Sinatra`
+2. User (System) Name: e.g. `frank`
+3. System Hostname: e.g. `franks-laptop`
 4. Combination of OS & Architecture: e.g. `darwin_amd64`
 
 It also removes disallowed characters and truncates the string to match the [requirements](https://aws.amazon.com/blogs/security/easily-control-naming-individual-iam-role-sessions/).

--- a/website/docs/role-session-name.md
+++ b/website/docs/role-session-name.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 10
+---
+
+
+# Role Session Name
+
+You can configure the Role Session Name via shared configuration file:
+```ini
+# ~/.aws/config
+[profile frank@concerts]
+credential_process = vegas-credentials assume --profile=frank@concerts
+vegas_role_arn = arn:aws:iam::222222222222:role/SingerRole
+vegas_source_profile = work
+role_session_name = SinatraAtTheSands
+```
+
+## Fallback value
+
+[AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) requires Role Session Name value to be set. If you do not provide one, Vegas Credentials will use a fallback value which is one of the following (in the following priority):
+1. User Full Name: e.g. `John Doe`
+2. User (System) Name: e.g. `john`
+3. System Hostname: e.g. `work-laptop`
+4. Combination of OS & Architecture: e.g. `darwin_amd64`
+
+It also removes disallowed characters and truncates the string to match the requirements of [IAM names](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length).


### PR DESCRIPTION
Fixes #22.

During the refactor to use AWS Go SDK v2, the internal logic was used from using [GetSessionToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html) operation to using [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) operation.

With AssumeRole operation, the RoleSessionName value is required, which causes a crash if none was provided.

Change from GetSessionToken to AssumeRole was initially a mistake but after some consideration, it actually feels more valid since:
1. AssumeRole operation respects _Maximum session duration setting_ set for the given role. 
2. An account Root can't use AssumeRole (and really, one should not use root to perform operations with vegas credentials)

[See comparison of AssumeRole vs. GetSessionToken](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison).

When using AssumeRole, one MUST provide _Role Session Name_. This PR adds functionality where a fallback value is set if user has not provided a value via `role_session_name` property in shared configuration file.

The fallback uses a logic where it tries to get one of the following values:
1. User Full Name: e.g. `John Doe`
2. User (System) Name: e.g. `john`
3. System Hostname: e.g. `work-laptop`

If none of them (in order) do not contain value with more than 2 characters, then OS & System Architecture is used (e.g. `darwin_amd64`).

This way, there will always be some what meaningful session identifier assigned to AssumeRole operation.