### PR TITLE
Fix: Hide sensitive input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.7.1
+	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171
 	gopkg.in/ini.v1 v1.66.4
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
@@ -80,7 +81,6 @@ require (
 	golang.org/x/image v0.0.0-20220321031419-a8550c1d254a // indirect
 	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
 	golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,8 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3 h1:kBsBifDikLCf5sUMbcD8p73OinDtAQWQp8+n7FiyzlA=
 golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 h1:EH1Deb8WZJ0xc0WK//leUHXcX9aLE5SymusoTmMZye8=
+golang.org/x/term v0.0.0-20220411215600-e5f449aeb171/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -67,7 +67,7 @@ func Error(prefix emoji.Emoji, message string) {
 }
 
 func Prompt(prefix emoji.Emoji, message string) {
-	d.Prompt(prefix, message)
+	d.Promptln(prefix, message)
 }
 
 func Fatal(message string) {

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -67,7 +67,7 @@ func Error(prefix emoji.Emoji, message string) {
 }
 
 func Prompt(prefix emoji.Emoji, message string) {
-	d.Promptln(prefix, message)
+	d.Prompt(prefix, message)
 }
 
 func Fatal(message string) {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,7 +1,9 @@
 package prompt
 
 import (
+	"bufio"
 	"context"
+	"os"
 	"strings"
 	"syscall"
 
@@ -36,7 +38,7 @@ func Dialog(ctx context.Context, title string, text string) (string, error) {
 	return strings.TrimSpace(value), nil
 }
 
-func Cli(ctx context.Context, text string) (string, error) {
+func CliPassword(ctx context.Context, text string) (string, error) {
 
 	value, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
@@ -44,4 +46,16 @@ func Cli(ctx context.Context, text string) (string, error) {
 	}
 
 	return strings.TrimSpace(string(value)), nil
+}
+
+func Cli(ctx context.Context, text string) (string, error) {
+
+	reader := bufio.NewReader(os.Stdin)
+
+	value, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(value), nil
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,12 +1,12 @@
 package prompt
 
 import (
-	"bufio"
 	"context"
-	"os"
 	"strings"
+	"syscall"
 
 	"github.com/ncruces/zenity"
+	"golang.org/x/term"
 )
 
 func Password(ctx context.Context, title string, text string) (string, error) {
@@ -37,12 +37,11 @@ func Dialog(ctx context.Context, title string, text string) (string, error) {
 }
 
 func Cli(ctx context.Context, text string) (string, error) {
-	reader := bufio.NewReader(os.Stdin)
 
-	value, err := reader.ReadString('\n')
+	value, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return "", err
 	}
 
-	return strings.TrimSpace(value), nil
+	return strings.TrimSpace(string(value)), nil
 }

--- a/internal/totp/message.go
+++ b/internal/totp/message.go
@@ -3,6 +3,7 @@ package totp
 import (
 	"bytes"
 	_ "embed"
+	"strings"
 
 	"github.com/aripalo/vegas-credentials/internal/msg"
 	"github.com/aripalo/vegas-credentials/internal/tmpl"
@@ -26,5 +27,5 @@ func formatInputMessage(enableGui bool, enableYubikey bool) string {
 	if err != nil {
 		msg.Fatal(err.Error())
 	}
-	return message.String()
+	return strings.TrimSpace(message.String())
 }

--- a/internal/yubikey/askpass/ask.go
+++ b/internal/yubikey/askpass/ask.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Assign CLI Prompt to variable (useful for testing).
-var cliPrompt = prompt.Cli
+var cliPrompt = prompt.CliPassword
 
 // Assign GUI Prompt to variable (useful for testing).
 var guiPrompt = prompt.Password


### PR DESCRIPTION
Fixes #28 by using Go's `golang.org/x/term` package's [ReadPassword](https://pkg.go.dev/golang.org/x/term#ReadPassword) method which is aimed for exactly these kind of purposes.

The Yubikey OATH application password is hidden:
![vegas-input-password](https://user-images.githubusercontent.com/679146/168144341-7f755bfc-80a4-4b77-b008-4d64be1e60c8.png)

… but the OATH TOTP (MFA Token) input is still visible (if provided via CLI `stdin`):
![vegas-input-token](https://user-images.githubusercontent.com/679146/168144329-65e22a08-e001-433c-8065-4ccca0e3689f.png)



